### PR TITLE
GitHub 이력서 콘테스트 참가 신청

### DIFF
--- a/registration.md
+++ b/registration.md
@@ -17,6 +17,7 @@
 * **3학년**
   - 강지현 / 3학년 / 20205107 / kangjihyunlo@naver.com / https://github.com/Kjhyun-2
   - 운석현 / 3학년 / 20205206 / woonsuck0916@naver.com / https://github.com/seokhyeon0916/seokhyeon0916.git
+  - 김경재 / 3학년 / 20205117 / dami1232@naver.com / https://portalcu.be/ ( https://github.com/PortalCube/portalcube-web )
 
 
 * **2학년**


### PR DESCRIPTION
한림대학교 GitHub 이력서 콘테스트 참가합니다.

포트폴리오 웹사이트 주소: https://portalcu.be/
포트폴리오 웹사이트 Github 레포지토리 주소: https://github.com/PortalCube/portalcube-web

registration.md 파일에 내용 추가하였습니다.